### PR TITLE
Fixing and upgrading workflow pipenv

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,8 +31,10 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm install
 
-      - name: Setup pipenv
-        run: pip install pipenv
+      - name: Setup pipenv environment
+        uses: dschep/install-pipenv-action@v1
+        with:
+          version: 2022.4.21
 
       - name: Serverless Deploy
         run: npm run deploy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup pipenv environment
         uses: dschep/install-pipenv-action@v1
         with:
-          version: 2021.5.29
+          version: 2022.4.21
 
       - name: Run an update in a pip environment
         run: |


### PR DESCRIPTION
- Updating pipenv to last known working version - 2022.4.21. 
- Consideration: maybe it's time to ditch pipenv and just use virtualenv.